### PR TITLE
adding coverage config, closes #14

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+source = pagseguro
+
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*


### PR DESCRIPTION
Como o Nosetests é utilizado, a documentação recomenda a criação de um .coveragerc:
https://pypi.python.org/pypi/coveralls
Isso deve evitar que ele reporte a cobertura de código externo ao projeto, como descrito nessa issue do coveralls:
https://github.com/coagulant/coveralls-python/issues/21
O que acham?
closes #14
