### PR TITLE
Add __getitem__ to PagSeguroNotificationResponse. 

### DIFF
--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -15,6 +15,9 @@ class PagSeguroNotificationResponse(object):
         self.config = config or {}
         self.parse_xml(xml)
 
+    def __getitem__(self, key):
+        getattr(self, key, None)
+
     def parse_xml(self, xml):
         try:
             parsed = xmltodict.parse(xml, encoding="iso-8859-1")


### PR DESCRIPTION
Now users can access attributes of the response with the syntax response[key].
