### PR TITLE
Enable user to pass their own Config object

### DIFF
--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -111,8 +111,8 @@ class PagSeguro(object):
     SEDEX = 2
     NONE = 3
 
-    def __init__(self, email, token, data=None):
-        self.config = Config()
+    def __init__(self, email, token, data=None, config=None):
+        self.config = Config() if not config else config
         self.data = {}
         self.data['email'] = email
         self.data['token'] = token

--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -112,7 +112,7 @@ class PagSeguro(object):
     NONE = 3
 
     def __init__(self, email, token, data=None, config=None):
-        self.config = Config() if not config else config
+        self.config = config or Config()
         self.data = {}
         self.data['email'] = email
         self.data['token'] = token


### PR DESCRIPTION
With this fix users will be able to create a custom Config class with the correct endpoint for the sandbox.