### PR TITLE
Added option to work with services sales, avoiding shipment addresses 

### DIFF
--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -261,7 +261,7 @@ class PagSeguro(object):
             params['senderBornDate'] = self.sender.get('born_date')
             params['senderHash'] = self.sender.get('hash')
 
-        if config.USE_SHIPPING
+        if self.config.USE_SHIPPING
             if self.shipping:
                 params['shippingType'] = self.shipping.get('type')
                 params['shippingAddressStreet'] = self.shipping.get('street')

--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -261,22 +261,24 @@ class PagSeguro(object):
             params['senderBornDate'] = self.sender.get('born_date')
             params['senderHash'] = self.sender.get('hash')
 
-        if self.shipping:
-            params['shippingType'] = self.shipping.get('type')
-            params['shippingAddressStreet'] = self.shipping.get('street')
-            params['shippingAddressNumber'] = self.shipping.get('number')
-            params['shippingAddressComplement'] = self.shipping.get(
-                'complement')
-            params['shippingAddressDistrict'] = self.shipping.get('district')
-            params['shippingAddressPostalCode'] = self.shipping.get(
-                'postal_code')
-            params['shippingAddressCity'] = self.shipping.get('city')
-            params['shippingAddressState'] = self.shipping.get('state')
-            params['shippingAddressCountry'] = self.shipping.get('country',
-                                                                 'BRA')
-
-        if self.shipping and self.shipping.get('cost'):
-            params['shippingCost'] = self.shipping.get('cost')
+        if config.USE_SHIPPING
+            if self.shipping:
+                params['shippingType'] = self.shipping.get('type')
+                params['shippingAddressStreet'] = self.shipping.get('street')
+                params['shippingAddressNumber'] = self.shipping.get('number')
+                params['shippingAddressComplement'] = self.shipping.get(
+                    'complement')
+                params['shippingAddressDistrict'] = self.shipping.get('district')
+                params['shippingAddressPostalCode'] = self.shipping.get(
+                    'postal_code')
+                params['shippingAddressCity'] = self.shipping.get('city')
+                params['shippingAddressState'] = self.shipping.get('state')
+                params['shippingAddressCountry'] = self.shipping.get('country',
+                                                                     'BRA')
+            if self.shipping and self.shipping.get('cost'):
+                params['shippingCost'] = self.shipping.get('cost')
+        else:
+            params['shippingAddressRequired'] = False
 
         if self.extra_amount:
             params['extraAmount'] = self.extra_amount

--- a/pagseguro/configs.py
+++ b/pagseguro/configs.py
@@ -155,6 +155,14 @@ class AbstractConfig(object):  # pragma: no cover
     @DATETIME_FORMAT.setter
     def DATETIME_FORMAT(self, value):
         self._DATETIME_FORMAT = value
+        
+    @abc.abstractproperty
+    def USE_SHIPPING(self):
+        return self._USE_SHIPPING
+        
+    @USE_SHIPPING.setter
+    def USE_SHIPPING(self, value):
+        self._USE_SHIPPING = value
 
 
 class Config(AbstractConfig):
@@ -187,6 +195,7 @@ class Config(AbstractConfig):
     PAYMENT_HOST = "https://pagseguro.uol.com.br"
     PAYMENT_URL = PAYMENT_HOST + CHECKOUT_SUFFIX + "/payment.html?code=%s"
     DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+    USE_SHIPPING = True
 
 
 class ConfigSandbox(AbstractConfig):
@@ -207,5 +216,5 @@ class ConfigSandbox(AbstractConfig):
     REFERENCE_PREFIX = "REF%s"
     PAYMENT_HOST = "https://sandbox.pagseguro.uol.com.br"
     PAYMENT_URL = PAYMENT_HOST + CHECKOUT_SUFFIX + "/payment.html?code=%s"
-
     DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S'
+    USE_SHIPPING = True


### PR DESCRIPTION
Hi all, 

According V2 API docs, I added an option at Config class with intent to reduce checkout steps when selling services that do not requires shipment addresses.
[pagseguro-api-pagamentos-anexo-checkout-servico.pdf](https://github.com/rochacbruno/python-pagseguro/files/439537/pagseguro-api-pagamentos-anexo-checkout-servico.pdf)

If it be useful, please feel free to do any enhancement 