### PR TITLE
Payments for services without shipping addresses requirement

### DIFF
--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -65,22 +65,25 @@ class PagSeguro(object):
             params['senderBornDate'] = self.sender.get('born_date')
             params['senderHash'] = self.sender.get('hash')
 
-        if self.shipping:
-            params['shippingType'] = self.shipping.get('type')
-            params['shippingAddressStreet'] = self.shipping.get('street')
-            params['shippingAddressNumber'] = self.shipping.get('number')
-            params['shippingAddressComplement'] = self.shipping.get(
-                'complement')
-            params['shippingAddressDistrict'] = self.shipping.get('district')
-            params['shippingAddressPostalCode'] = self.shipping.get(
-                'postal_code')
-            params['shippingAddressCity'] = self.shipping.get('city')
-            params['shippingAddressState'] = self.shipping.get('state')
-            params['shippingAddressCountry'] = self.shipping.get('country',
-                                                                 'BRA')
-
-        if self.shipping and self.shipping.get('cost'):
-            params['shippingCost'] = self.shipping.get('cost')
+        if self.config.USE_SHIPPING:
+            if self.shipping:
+                params['shippingType'] = self.shipping.get('type')
+                params['shippingAddressStreet'] = self.shipping.get('street')
+                params['shippingAddressNumber'] = self.shipping.get('number')
+                params['shippingAddressComplement'] = self.shipping.get(
+                    'complement')
+                params['shippingAddressDistrict'] = self.shipping.get('district')
+                params['shippingAddressPostalCode'] = self.shipping.get(
+                    'postal_code')
+                params['shippingAddressCity'] = self.shipping.get('city')
+                params['shippingAddressState'] = self.shipping.get('state')
+                params['shippingAddressCountry'] = self.shipping.get('country',
+                                                                     'BRA')
+                
+            if self.shipping.get('cost'):
+                params['shippingCost'] = self.shipping.get('cost')
+        else:
+            params['shippingAddressRequired'] = False
 
         if self.extra_amount:
             params['extraAmount'] = self.extra_amount

--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -79,9 +79,8 @@ class PagSeguro(object):
                 params['shippingAddressState'] = self.shipping.get('state')
                 params['shippingAddressCountry'] = self.shipping.get('country',
                                                                      'BRA')
-                
-            if self.shipping.get('cost'):
-                params['shippingCost'] = self.shipping.get('cost')
+                if self.shipping.get('cost'):
+                    params['shippingCost'] = self.shipping.get('cost')
         else:
             params['shippingAddressRequired'] = False
 

--- a/pagseguro/config.py
+++ b/pagseguro/config.py
@@ -45,7 +45,7 @@ class Config(dict):
                 payment_host, checkout_suffix),
             DATETIME_FORMAT='%Y-%m-%dT%H:%M:%S',
             REFERENCE_PREFIX='REF%s',
-            USE_SHIPPING=False,
+            USE_SHIPPING=True,
         )
 
         kwargs = {key.upper(): val for key, val in kwargs.items()}

--- a/pagseguro/config.py
+++ b/pagseguro/config.py
@@ -45,6 +45,7 @@ class Config(dict):
                 payment_host, checkout_suffix),
             DATETIME_FORMAT='%Y-%m-%dT%H:%M:%S',
             REFERENCE_PREFIX='REF%s',
+            USE_SHIPPING=False,
         )
 
         kwargs = {key.upper(): val for key, val in kwargs.items()}


### PR DESCRIPTION
Code implementation according PagSeguro's V2 docs. This implementation allows payments without mandatory shipping addresses.

I closed another previous pull request with same implementation cause this one has New Config file structure.

Please, feel free to do any necessary enhancements,

Regards 

[pagseguro-api-pagamentos-anexo-checkout-servico.pdf](https://github.com/rochacbruno/python-pagseguro/files/459301/pagseguro-api-pagamentos-anexo-checkout-servico.pdf)
 