### PR TITLE
Suporte a Python 3.5

### DIFF
--- a/examples/flask/flask_seguro/cart.py
+++ b/examples/flask/flask_seguro/cart.py
@@ -29,8 +29,7 @@ class Cart:
             if operation == 'add':
                 self.items.append(product)
             elif operation == 'remove':
-                cart_product = filter(
-                    lambda x: x['id'] == product['id'], self.items)
+                cart_product = [x for x in self.items if x['id'] == product['id']]
                 self.items.remove(cart_product[0])
             self.update()
             return True

--- a/examples/flask/flask_seguro/products.py
+++ b/examples/flask/flask_seguro/products.py
@@ -23,7 +23,7 @@ class Products:
         return self.products
 
     def get_one(self, item_id):
-        p = filter(lambda p: p['id'] == item_id, self.products)
+        p = [p for p in self.products if p['id'] == item_id]
         if len(p) > 0:
             return p[0]
         else:

--- a/examples/flask/tests.py
+++ b/examples/flask/tests.py
@@ -38,21 +38,21 @@ class FlasKSeguroTestCase(unittest.TestCase):
             response = c.get('/')
             session = flask.session
             self.assertIn('cart', session)
-            self.assertEquals(0, len(session['cart']['items']))
+            self.assertEqual(0, len(session['cart']['items']))
 
             products = self.list_products()
 
             response = c.get('/cart/add/%s' % (products[0]['id']))
-            self.assertEquals(1, len(session['cart']['items']))
+            self.assertEqual(1, len(session['cart']['items']))
             cart = self.check_cart_fields(response)
-            self.assertEquals(
+            self.assertEqual(
                 float(cart['subtotal']), float(products[0]['price']))
 
             response = c.get('/cart/remove/%s' % (products[0]['id']))
-            self.assertEquals(0, len(session['cart']['items']))
+            self.assertEqual(0, len(session['cart']['items']))
             cart = self.check_cart_fields(response)
-            self.assertEquals(0, float(cart['total']))
-            self.assertEquals(float(cart['total']), float(cart['subtotal']))
+            self.assertEqual(0, float(cart['total']))
+            self.assertEqual(float(cart['total']), float(cart['subtotal']))
 
     def checkout(self, data, c, decode_json=True):
         response = c.post('/checkout', data=data)
@@ -65,7 +65,7 @@ class FlasKSeguroTestCase(unittest.TestCase):
             response = c.get('/')
             session = flask.session
 
-            self.assertEquals(0, len(session['cart']['items']))
+            self.assertEqual(0, len(session['cart']['items']))
 
             data = {
                 "name": "Victor Shyba",
@@ -81,25 +81,25 @@ class FlasKSeguroTestCase(unittest.TestCase):
 
             response = self.checkout(data, c)
             self.assertIn('error_msg', response)
-            self.assertEquals(
+            self.assertEqual(
                 u'Seu carrinho está vazio.', response['error_msg'])
 
             response = self.checkout({}, c)
             self.assertIn('error_msg', response)
-            self.assertEquals(
+            self.assertEqual(
                 u'Todos os campos são obrigatórios.', response['error_msg'])
 
             products = self.list_products()
             response = c.get('/cart/add/%s' % (products[0]['id']))
-            self.assertEquals(1, len(session['cart']['items']))
+            self.assertEqual(1, len(session['cart']['items']))
 
             response = self.checkout(data, c, decode_json=False)
-            self.assertEquals(302, response.status_code)
+            self.assertEqual(302, response.status_code)
             self.assertIn('pagseguro', response.location)
 
     def test_cart_view(self):
         response = self.app.get('/cart')
-        self.assertEquals(200, response.status_code)
+        self.assertEqual(200, response.status_code)
 
 
 if __name__ == '__main__':

--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -184,7 +184,7 @@ class PagSeguro(object):
 
     def clean_none_params(self):
         self.data = \
-            {k: v for k, v in self.data.items() if v or isinstance(v, bool)}
+            {k: v for k, v in list(self.data.items()) if v or isinstance(v, bool)}
 
     @property
     def reference_prefix(self):

--- a/pagseguro/config.py
+++ b/pagseguro/config.py
@@ -48,8 +48,8 @@ class Config(dict):
             USE_SHIPPING=True,
         )
 
-        kwargs = {key.upper(): val for key, val in kwargs.items()}
-        keys = defaults.keys()
+        kwargs = {key.upper(): val for key, val in list(kwargs.items())}
+        keys = list(defaults.keys())
         for key in keys:
             # only add override keys to properties
             value = kwargs.pop(key, defaults[key])

--- a/pagseguro/parsers.py
+++ b/pagseguro/parsers.py
@@ -41,7 +41,7 @@ class PagSeguroNotificationResponse(XMLParser):
         if self.errors:
             return
         transaction = parsed.get('transaction', {})
-        for k, v in transaction.items():
+        for k, v in list(transaction.items()):
             setattr(self, k, v)
 
 
@@ -55,7 +55,7 @@ class PagSeguroPreApprovalNotificationResponse(XMLParser):
         if self.errors:
             return
         transaction = parsed.get('transaction', {})
-        for k, v in transaction.items():
+        for k, v in list(transaction.items()):
             setattr(self, k, v)
 
 
@@ -68,7 +68,7 @@ class PagSeguroPreApprovalCancel(XMLParser):
         if self.errors:
             return
         transaction = parsed.get('transaction', {})
-        for k, v in transaction.items():
+        for k, v in list(transaction.items()):
             setattr(self, k, v)
 
 

--- a/pagseguro/utils.py
+++ b/pagseguro/utils.py
@@ -114,12 +114,12 @@ def is_valid_cnpj(value):
 
     orig_dv = value[-2:]
 
-    new_1dv = sum([i * int(value[idx]) for idx, i in enumerate(range(
-        5, 1, -1) + range(9, 1, -1))])
+    new_1dv = sum([i * int(value[idx]) for idx, i in enumerate(list(range(
+        5, 1, -1)) + list(range(9, 1, -1)))])
     new_1dv = DV_maker(new_1dv % 11)
     value = value[:-2] + str(new_1dv) + value[-1]
-    new_2dv = sum([i * int(value[idx]) for idx, i in enumerate(range(
-        6, 1, -1) + range(9, 1, -1))])
+    new_2dv = sum([i * int(value[idx]) for idx, i in enumerate(list(range(
+        6, 1, -1)) + list(range(9, 1, -1)))])
     new_2dv = DV_maker(new_2dv % 11)
     value = value[:-1] + str(new_2dv)
     if value[-2:] != orig_dv:

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
-import codecs
+import io
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-with codecs.open('README.md', encoding='utf-8') as readme_fd:
+with io.open('README.md', encoding='utf-8') as readme_fd:
     readme = readme_fd.read()
 
-with open('requirements.txt') as reqs:
+with io.open('requirements.txt') as reqs:
     requirements = reqs.read().split()
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.5',
     ],
     keywords='pagseguro, payment, payments, credit-card'
 )

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
+import codecs
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
 
-readme = open('README.md').read()
+with codecs.open('README.md', encoding='utf-8') as readme_fd:
+    readme = readme_fd.read()
 
 with open('requirements.txt') as reqs:
     requirements = reqs.read().split()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,14 +34,15 @@ def common_config():
 
 def test_common_config(common_config):
     c = Config()
-    for key, val in common_config.items():
-        print key, val
+    for key, val in list(common_config.items()):
+        print((key, val))
         assert getattr(c, key) == common_config[key]
 
 
 def test_custom_config(custom_config):
     c = Config(**custom_config)
     assert c.PAYMENT_URL == custom_config['payment_url']
+
 
 def test_config_special_methods():
     c = Config()

--- a/tests/test_pagseguro.py
+++ b/tests/test_pagseguro.py
@@ -109,7 +109,7 @@ def test_build_checkout_params_with_all_params(pagseguro, sender, shipping,
         assert key in pagseguro.data
 
     for i, key in enumerate(pagseguro.items, 1):
-        keys_to_compare = map(lambda x: x.format(i), item_keys)
+        keys_to_compare = [x.format(i) for x in item_keys]
         for item_key in keys_to_compare:
             assert item_key in pagseguro.data
 
@@ -123,7 +123,7 @@ def test_add_items_util(items):
 
 def test_reference(pagseguro):
     pagseguro.reference = '12345'
-    assert unicode(pagseguro.reference) == u'REF12345'
+    assert pagseguro.reference == u'REF12345'
 
 
 def test_clean_none_params(sender):

--- a/tests/test_pagseguro_sandbox.py
+++ b/tests/test_pagseguro_sandbox.py
@@ -110,7 +110,7 @@ def test_build_checkout_params_with_all_params(pagseguro_sandbox, sender,
         assert key in pagseguro_sandbox.data
 
     for i, key in enumerate(pagseguro_sandbox.items, 1):
-        keys_to_compare = map(lambda x: x.format(i), item_keys)
+        keys_to_compare = [x.format(i) for x in item_keys]
         for item_key in keys_to_compare:
             assert item_key in pagseguro_sandbox.data
 


### PR DESCRIPTION
Tive problemas de encoding no setup.py ao tentar instalar a versão 0.3.2 do python-pagseguro no python3.5. Assim, acabei fazendo os ajustes necessários nesse arquivo e também executei a ferramenta 2to3 em todo o código. Tomei o cuidado de manter a compatibilidade no python2 e python3.