### PR TITLE
Add python 3 support to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
-    - 2.7
+    - "2.7"
+    - "3.4"
+    - "3.5"
+    - "3.6"
 before_install:
     - "pip install coveralls"
     - "pip install -r requirements_dev.txt"


### PR DESCRIPTION
Now the project has support to Python 3.x, we need to update Travis-CI to support it as well. 

Note: I didn't add 3.7 or 3.7-dev because 
> [recent Python branches require OpenSSL 1.0.2+. As this library is not available for Trusty, 3.7, 3.7-dev, 3.8-dev, and nightly do not work](https://docs.travis-ci.com/user/languages/python/#Development-releases-support)