### PR TITLE
Fix disabling shipping with USE_SHIPPING=False config

### DIFF
--- a/pagseguro/__init__.py
+++ b/pagseguro/__init__.py
@@ -83,7 +83,7 @@ class PagSeguro(object):
                 if self.shipping.get('cost'):
                     params['shippingCost'] = self.shipping.get('cost')
         else:
-            params['shippingAddressRequired'] = False
+            params['shippingAddressRequired'] = 'false'
 
         if self.extra_amount:
             params['extraAmount'] = self.extra_amount


### PR DESCRIPTION
The requests lib encode boolean values on params with capital case, but PagSeguro service reject `'False'` as value for parameter `shippingAddressRequired`, preveting the conclusion of checkout operations.

Fixes #67